### PR TITLE
Feature/java plugin compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,13 @@ sudo: true
 jdk:
 - oraclejdk7
 install: true
-script: "./gradle/buildViaTravis.sh"
+script: travis_wait 20 "./gradle/buildViaTravis.sh"
 cache:
   directories:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
 before_install:
-- travis_wait 20 test $TRAVIS_PULL_REQUEST = false && openssl aes-256-cbc -K $encrypted_fd546f631468_key -iv $encrypted_fd546f631468_iv
+- test $TRAVIS_PULL_REQUEST = false && openssl aes-256-cbc -K $encrypted_fd546f631468_key -iv $encrypted_fd546f631468_iv
   -in gradle.properties.enc -out gradle.properties -d || true
 after_success:
 - "./gradlew jacocoTestReport coveralls"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: true
 jdk:
 - oraclejdk7
 install: true
-script: travis_wait 20 "./gradle/buildViaTravis.sh"
+script: "./gradle/buildViaTravis.sh"
 cache:
   directories:
     - $HOME/.gradle/caches/

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ cache:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
 before_install:
-- test $TRAVIS_PULL_REQUEST = false && openssl aes-256-cbc -K $encrypted_fd546f631468_key -iv $encrypted_fd546f631468_iv
+- travis_wait 20 test $TRAVIS_PULL_REQUEST = false && openssl aes-256-cbc -K $encrypted_fd546f631468_key -iv $encrypted_fd546f631468_iv
   -in gradle.properties.enc -out gradle.properties -d || true
 after_success:
 - "./gradlew jacocoTestReport coveralls"

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     compile ('org.grails:grails-launcher:1.1') {
         exclude module: 'groovy-all'
     }
+    testCompile "gradle.plugin.com.gorylenko.gradle-git-properties:gradle-git-properties:1.4.17"
 }
 
 pluginBundle {

--- a/src/main/groovy/com/netflix/nebula/grails/internal/DefaultGrailsProject.groovy
+++ b/src/main/groovy/com/netflix/nebula/grails/internal/DefaultGrailsProject.groovy
@@ -120,7 +120,7 @@ public class DefaultGrailsProject implements GrailsProject {
      */
     public MavenArtifactRepository central() {
         project.repositories.maven { MavenArtifactRepository repository ->
-            repository.url = 'http://repo.grails.org/grails/repo'
+            repository.url = 'https://repo.grails.org/grails/core'
             repository.name = 'Grails Central'
         }
     }

--- a/src/main/groovy/com/netflix/nebula/grails/tasks/GrailsTaskConfigurator.groovy
+++ b/src/main/groovy/com/netflix/nebula/grails/tasks/GrailsTaskConfigurator.groovy
@@ -47,7 +47,7 @@ class GrailsTaskConfigurator {
         }
 
         //Create the Grails test task.
-        project.tasks.create(GRAILS_TEST_TASK, GrailsTestTask)
+        project.tasks.create(name: GRAILS_TEST_TASK, type: GrailsTestTask, overwrite: true)
 
         //Create a task rule that converts any task with that starts with 'grail-' into an invocation of
         //the corresponding Grails script

--- a/src/test/groovy/com/netflix/nebula/grails/TaskConfigurationSpec.groovy
+++ b/src/test/groovy/com/netflix/nebula/grails/TaskConfigurationSpec.groovy
@@ -170,4 +170,17 @@ class ${project.name.capitalize()}GrailsPlugin { }
         expect:
         assert project.tasks.findByName('test')
     }
+
+    def "grails.nebula plugin can be applied after implicitly applied java plugin"() {
+        given:
+        project = ProjectBuilder.builder().build()
+
+        project.apply plugin: com.gorylenko.GitPropertiesPlugin
+        project.apply plugin: "nebula.grails"
+        project.grails.grailsVersion = '2.0.0'
+        project.evaluate()
+
+        expect:
+        assert project.tasks.findByName('test')
+    }
 }

--- a/src/test/groovy/com/netflix/nebula/grails/TaskConfigurationSpec.groovy
+++ b/src/test/groovy/com/netflix/nebula/grails/TaskConfigurationSpec.groovy
@@ -157,4 +157,17 @@ class ${project.name.capitalize()}GrailsPlugin { }
         then:
         notThrown(Exception)
     }
+
+    def "grails.nebula plugin can be applied after java plugin"() {
+        given:
+        project = ProjectBuilder.builder().build()
+
+        project.apply plugin: "java"
+        project.apply plugin: "nebula.grails"
+        project.grails.grailsVersion = '2.0.0'
+        project.evaluate()
+
+        expect:
+        assert project.tasks.findByName('test')
+    }
 }


### PR DESCRIPTION
Enable compatibility with "java" plugin to be able to use nebula.grails in projects where "java" plugin is applied explicitly (or implicitly by other plugins like "gradile-git-properties" plugin)

Test and fix were added in separate commits.
